### PR TITLE
update install sh removing dbtools* dir

### DIFF
--- a/scripts/install-sqlcl.sh
+++ b/scripts/install-sqlcl.sh
@@ -8,8 +8,8 @@ unzip sqlcl*.zip
 # Cleanup
 rm -rf sqlcl*.zip
 
-# The unzip will create a folder like: dbtools-sqlcl-18.1.0
-cd dbtools*
+# The unzip will create a folder like: sqlcl
+cd sqlcl*
 
 # Rename 2sql binary if provided
 if [ ! -z "$SQLCL_BIN_NAME" ]; then


### PR DESCRIPTION
It seems that newer versions of sqlcl*.zip files don't have this directory